### PR TITLE
Replace np.int by int

### DIFF
--- a/pyeer/eer_stats.py
+++ b/pyeer/eer_stats.py
@@ -149,10 +149,10 @@ def calculate_roc(gscores, iscores, ds_scores=False, rates=True):
     if isinstance(iscores, list):
         iscores = np.array(iscores, dtype=np.float64)
 
-    if gscores.dtype == np.int:
+    if gscores.dtype == int:
         gscores = np.float64(gscores)
 
-    if iscores.dtype == np.int:
+    if iscores.dtype == int:
         iscores = np.float64(iscores)
 
     if ds_scores:


### PR DESCRIPTION
`numpy` has deprecated and removed `numpy.int` in newer versions, compare https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated.

It was basically identical to the build-in `int`, so I would propose to simply replace it by this.